### PR TITLE
Fix issue with ansible-playbook --check execution when version == latest

### DIFF
--- a/tasks/setup-Linux-Unix.yml
+++ b/tasks/setup-Linux-Unix.yml
@@ -7,6 +7,7 @@
     return_content: yes
   register: terraform_index
   when: terraform_version == "latest"
+  check_mode: no
 
 - name: Linux/Unix | Finds the latest Terraform version when latest var is define
   set_fact:

--- a/tasks/setup-Windows.yml
+++ b/tasks/setup-Windows.yml
@@ -7,6 +7,7 @@
     return_content: yes
   register: terraform_index
   when: terraform_version == 'latest'
+  check_mode: no
 
 - name: Windows | Finds the latest Terraform version when latest var is define
   set_fact:


### PR DESCRIPTION
When trying to run `ansible-playbook --check` with this role and `terraform_version == latest` variable set, the check execution fails at following step:
```
TASK [ansible-role-terraform : Linux/Unix | Finds the latest Terraform version when latest var is define]
FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ (terraform_index.content | from_json).versions | reject('search','-') | list | sort_versions | last }}): expected string or buffer"
```

This is due to the fact, the `terraform_index.content` is not defined in previous step. In normal run content is downloaded with uri module, but when executed with --check it's empty/skipped, as per message
`"msg": "remote module (uri) does not support check mode"`

Considering uri step does not modify any contents on the target, it is safe to execute this step also in the --check mode. To enable such functionality - `check_mode: no` can be used. Details are documented here: https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html 

This simple commit integrates required changes and makes role work well with `--check` invocation.
